### PR TITLE
Add GraphQL Extension

### DIFF
--- a/extensions/graphql/config/settings.json
+++ b/extensions/graphql/config/settings.json
@@ -1,0 +1,8 @@
+{
+  "endpoint": "/graphql",
+  "tracing": false,
+  "shadowCRUD": true,
+  "playgroundAlways": false,
+  "depthLimit": 7,
+  "amountLimit": 100
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,46 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@apollo/protobufjs": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@apollo/protobufjs/-/protobufjs-1.0.4.tgz",
+      "integrity": "sha512-EE3zx+/D/wur/JiLp6VCiw1iYdyy1lCJMf8CGPkLeDt5QJrN4N8tKFx33Ah4V30AUQzMk7Uz4IXKZ1LOj124gA==",
+      "requires": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/long": "^4.0.0",
+        "@types/node": "^10.1.0",
+        "long": "^4.0.0"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "10.17.26",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.26.tgz",
+          "integrity": "sha512-myMwkO2Cr82kirHY8uknNRHEVtn0wV3DTQfkrjx17jmkstDRZ24gNUdl8AHXVyVclTYI/bNjgTPTAWvWLqXqkw=="
+        }
+      }
+    },
+    "@apollographql/apollo-tools": {
+      "version": "0.4.8",
+      "resolved": "https://registry.npmjs.org/@apollographql/apollo-tools/-/apollo-tools-0.4.8.tgz",
+      "integrity": "sha512-W2+HB8Y7ifowcf3YyPHgDI05izyRtOeZ4MqIr7LbTArtmJ0ZHULWpn84SGMW7NAvTV1tFExpHlveHhnXuJfuGA==",
+      "requires": {
+        "apollo-env": "^0.6.5"
+      }
+    },
+    "@apollographql/graphql-playground-html": {
+      "version": "1.6.24",
+      "resolved": "https://registry.npmjs.org/@apollographql/graphql-playground-html/-/graphql-playground-html-1.6.24.tgz",
+      "integrity": "sha512-8GqG48m1XqyXh4mIZrtB5xOhUwSsh1WsrrsaZQOEYYql3YN9DEu9OOSg0ILzXHZo/h2Q74777YE4YzlArQzQEQ=="
+    },
     "@babel/code-frame": {
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
@@ -1284,6 +1324,60 @@
         "vary": "^1.1.2"
       }
     },
+    "@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha1-m4sMxmPWaafY9vXQiToU00jzD78="
+    },
+    "@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="
+    },
+    "@protobufjs/codegen": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg=="
+    },
+    "@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha1-NVy8mLr61ZePntCV85diHx0Ga3A="
+    },
+    "@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha1-upn7WYYUr2VwDBYZ/wbUVLDYTEU=",
+      "requires": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha1-Xp4avctz/Ap8uLKR33jIy9l7h9E="
+    },
+    "@protobufjs/inquire": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+      "integrity": "sha1-/yAOPnzyQp4tyvwRQIKOjMY48Ik="
+    },
+    "@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha1-bMKyDFya1q0NzP0hynZz2Nf79o0="
+    },
+    "@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha1-Cf0V8tbTq/qbZbw2ZQbWrXhG/1Q="
+    },
+    "@protobufjs/utf8": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+      "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
+    },
     "@purest/config": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@purest/config/-/config-1.0.1.tgz",
@@ -1450,10 +1544,80 @@
         }
       }
     },
+    "@types/accepts": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@types/accepts/-/accepts-1.3.5.tgz",
+      "integrity": "sha512-jOdnI/3qTpHABjM5cx1Hc0sKsPoYCp+DP/GJRGtDlPd7fiV9oXGGIcjW/ZOxLIvjGz8MA+uMZI9metHlgqbgwQ==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/body-parser": {
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.0.tgz",
+      "integrity": "sha512-W98JrE0j2K78swW4ukqMleo8R7h/pFETjM2DQ90MF6XK2i4LO4W3gQ71Lt4w3bfm2EvVSyWHplECvB5sK22yFQ==",
+      "requires": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "@types/connect": {
+      "version": "3.4.33",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.33.tgz",
+      "integrity": "sha512-2+FrkXY4zllzTNfJth7jOqEHC+enpLeGslEhpnTAkg21GkRrWV4SsAtqchtT4YS9/nODBU2/ZfsBY2X4J/dX7A==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/content-disposition": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/@types/content-disposition/-/content-disposition-0.5.3.tgz",
+      "integrity": "sha512-P1bffQfhD3O4LW0ioENXUhZ9OIa0Zn+P7M+pWgkCKaT53wVLSq0mrKksCID/FGHpFhRSxRGhgrQmfhRuzwtKdg=="
+    },
+    "@types/cookies": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/@types/cookies/-/cookies-0.7.4.tgz",
+      "integrity": "sha512-oTGtMzZZAVuEjTwCjIh8T8FrC8n/uwy+PG0yTvQcdZ7etoel7C7/3MSd7qrukENTgQtotG7gvBlBojuVs7X5rw==",
+      "requires": {
+        "@types/connect": "*",
+        "@types/express": "*",
+        "@types/keygrip": "*",
+        "@types/node": "*"
+      }
+    },
+    "@types/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-invOmosX0DqbpA+cE2yoHGUlF/blyf7nB0OGYBBiH27crcVm5NmFaZkLP4Ta1hGaesckCi5lVLlydNJCxkTOSg==",
+      "requires": {
+        "@types/express": "*"
+      }
+    },
     "@types/events": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
       "integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g=="
+    },
+    "@types/express": {
+      "version": "4.17.6",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.6.tgz",
+      "integrity": "sha512-n/mr9tZI83kd4azlPG5y997C/M4DNABK9yErhFM6hKdym4kkmd9j0vtsJyjFIwfRBxtrxZtAfGZCNRIBMFLK5w==",
+      "requires": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "*",
+        "@types/qs": "*",
+        "@types/serve-static": "*"
+      }
+    },
+    "@types/express-serve-static-core": {
+      "version": "4.17.7",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.7.tgz",
+      "integrity": "sha512-EMgTj/DF9qpgLXyc+Btimg+XoH7A2liE8uKul8qSmMTHCeNYzydDKFdsJskDvw42UsesCnhO63dO0Grbj8J4Dw==",
+      "requires": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*"
+      }
     },
     "@types/formidable": {
       "version": "1.0.31",
@@ -1461,6 +1625,14 @@
       "integrity": "sha512-dIhM5t8lRP0oWe2HF8MuPvdd1TpPTjhDMAqemcq6oIZQCBQTovhBAdTQ5L5veJB4pdQChadmHuxtB0YzqvfU3Q==",
       "requires": {
         "@types/events": "*",
+        "@types/node": "*"
+      }
+    },
+    "@types/fs-capacitor": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/fs-capacitor/-/fs-capacitor-2.0.0.tgz",
+      "integrity": "sha512-FKVPOCFbhCvZxpVAMhdBdTfVfXUpsh15wFHgqOKxh9N9vzWZVuWCSijZ5T4U34XYNnuj2oduh6xcs1i+LPI+BQ==",
+      "requires": {
         "@types/node": "*"
       }
     },
@@ -1474,6 +1646,17 @@
         "@types/node": "*"
       }
     },
+    "@types/graphql-upload": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/@types/graphql-upload/-/graphql-upload-8.0.3.tgz",
+      "integrity": "sha512-hmLg9pCU/GmxBscg8GCr1vmSoEmbItNNxdD5YH2TJkXm//8atjwuprB+xJBK714JG1dkxbbhp5RHX+Pz1KsCMA==",
+      "requires": {
+        "@types/express": "*",
+        "@types/fs-capacitor": "*",
+        "@types/koa": "*",
+        "graphql": "^14.5.3"
+      }
+    },
     "@types/hoist-non-react-statics": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
@@ -1483,10 +1666,68 @@
         "hoist-non-react-statics": "^3.3.0"
       }
     },
+    "@types/http-assert": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@types/http-assert/-/http-assert-1.5.1.tgz",
+      "integrity": "sha512-PGAK759pxyfXE78NbKxyfRcWYA/KwW17X290cNev/qAsn9eQIxkH4shoNBafH37wewhDG/0p1cHPbK6+SzZjWQ=="
+    },
     "@types/invariant": {
       "version": "2.2.33",
       "resolved": "https://registry.npmjs.org/@types/invariant/-/invariant-2.2.33.tgz",
       "integrity": "sha512-/jUNmS8d4bCKdqslfxW6dg/9Gksfzxz67IYfqApHn+HvHlMVXwYv2zpTDnS/yaK9BB0i0GlBTaYci0EFE62Hmw=="
+    },
+    "@types/keygrip": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@types/keygrip/-/keygrip-1.0.2.tgz",
+      "integrity": "sha512-GJhpTepz2udxGexqos8wgaBx4I/zWIDPh/KOGEwAqtuGDkOUJu5eFvwmdBX4AmB8Odsr+9pHCQqiAqDL/yKMKw=="
+    },
+    "@types/koa": {
+      "version": "2.11.3",
+      "resolved": "https://registry.npmjs.org/@types/koa/-/koa-2.11.3.tgz",
+      "integrity": "sha512-ABxVkrNWa4O/Jp24EYI/hRNqEVRlhB9g09p48neQp4m3xL1TJtdWk2NyNQSMCU45ejeELMQZBYyfstyVvO2H3Q==",
+      "requires": {
+        "@types/accepts": "*",
+        "@types/content-disposition": "*",
+        "@types/cookies": "*",
+        "@types/http-assert": "*",
+        "@types/keygrip": "*",
+        "@types/koa-compose": "*",
+        "@types/node": "*"
+      }
+    },
+    "@types/koa-bodyparser": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@types/koa-bodyparser/-/koa-bodyparser-4.3.0.tgz",
+      "integrity": "sha512-aB/vwwq4G9FAtKzqZ2p8UHTscXxZvICFKVjuckqxCtkX1Ro7F5KHkTCUqTRZFBgDoEkmeca+bFLI1bIsdPPZTA==",
+      "requires": {
+        "@types/koa": "*"
+      }
+    },
+    "@types/koa-compose": {
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/@types/koa-compose/-/koa-compose-3.2.5.tgz",
+      "integrity": "sha512-B8nG/OoE1ORZqCkBVsup/AKcvjdgoHnfi4pZMn5UwAPCbhk/96xyv284eBYW8JlQbQ7zDmnpFr68I/40mFoIBQ==",
+      "requires": {
+        "@types/koa": "*"
+      }
+    },
+    "@types/koa__cors": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/@types/koa__cors/-/koa__cors-2.2.3.tgz",
+      "integrity": "sha512-RfG2EuSc+nv/E+xbDSLW8KCoeri/3AkqwVPuENfF/DctllRoXhooboO//Sw7yFtkLvj7nG7O1H3JcZmoTQz8nQ==",
+      "requires": {
+        "@types/koa": "*"
+      }
+    },
+    "@types/long": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.1.tgz",
+      "integrity": "sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w=="
+    },
+    "@types/mime": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-2.0.2.tgz",
+      "integrity": "sha512-4kPlzbljFcsttWEq6aBW0OZe6BDajAmyvr2xknBG92tejQnvdGtT9+kXSZ580DqpxY9qG2xeQVF9Dq0ymUTo5Q=="
     },
     "@types/minimatch": {
       "version": "3.0.3",
@@ -1498,6 +1739,27 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.5.tgz",
       "integrity": "sha512-90hiq6/VqtQgX8Sp0EzeIsv3r+ellbGj4URKj5j30tLlZvRUpnAe9YbYnjl3pJM93GyXU0tghHhvXHq+5rnCKA=="
     },
+    "@types/node-fetch": {
+      "version": "2.5.7",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.7.tgz",
+      "integrity": "sha512-o2WVNf5UhWRkxlf6eq+jMZDu7kjgpgJfl4xVNlvryc95O/6F2ld8ztKX+qu+Rjyet93WAWm5LjeX9H5FGkODvw==",
+      "requires": {
+        "@types/node": "*",
+        "form-data": "^3.0.0"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.0.tgz",
+          "integrity": "sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        }
+      }
+    },
     "@types/parse-json": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
@@ -1508,6 +1770,16 @@
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.3.tgz",
       "integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw=="
     },
+    "@types/qs": {
+      "version": "6.9.3",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.3.tgz",
+      "integrity": "sha512-7s9EQWupR1fTc2pSMtXRQ9w9gLOcrJn+h7HOXw4evxyvVqMi4f+q7d2tnFe3ng3SNHjtK+0EzGMGFUQX4/AQRA=="
+    },
+    "@types/range-parser": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.3.tgz",
+      "integrity": "sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA=="
+    },
     "@types/react": {
       "version": "16.9.35",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.35.tgz",
@@ -1515,6 +1787,23 @@
       "requires": {
         "@types/prop-types": "*",
         "csstype": "^2.2.0"
+      }
+    },
+    "@types/serve-static": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.4.tgz",
+      "integrity": "sha512-jTDt0o/YbpNwZbQmE/+2e+lfjJEJJR0I3OFaKQKPWkASkCoW3i6fsUnqudSMcNAfbtmADGu8f4MV4q+GqULmug==",
+      "requires": {
+        "@types/express-serve-static-core": "*",
+        "@types/mime": "*"
+      }
+    },
+    "@types/ws": {
+      "version": "7.2.5",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-7.2.5.tgz",
+      "integrity": "sha512-4UEih9BI1nBKii385G9id1oFrSkLcClbwtDfcYj8HJLQqZVAtb/42vXVrYvRWCcufNF/a+rZD3MxNwghA7UmCg==",
+      "requires": {
+        "@types/node": "*"
       }
     },
     "@webassemblyjs/ast": {
@@ -1674,6 +1963,14 @@
         "@xtuc/long": "4.2.2"
       }
     },
+    "@wry/equality": {
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.1.11.tgz",
+      "integrity": "sha512-mwEVBDUVODlsQQ5dfuLUS5/Tf7jqUKyhKYHmVi4fPB6bDMOfWvUPJmKgS1Z7Za/sOI3vzWt4+O7yCiL/70MogA==",
+      "requires": {
+        "tslib": "^1.9.3"
+      }
+    },
     "@xtuc/ieee754": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
@@ -1796,6 +2093,313 @@
         "picomatch": "^2.0.4"
       }
     },
+    "apollo-cache-control": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/apollo-cache-control/-/apollo-cache-control-0.11.0.tgz",
+      "integrity": "sha512-dmRnQ9AXGw2SHahVGLzB/p4UW/taFBAJxifxubp8hqY5p9qdlSu4MPRq8zvV2ULMYf50rBtZyC4C+dZLqmHuHQ==",
+      "requires": {
+        "apollo-server-env": "^2.4.4",
+        "apollo-server-plugin-base": "^0.9.0"
+      }
+    },
+    "apollo-datasource": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/apollo-datasource/-/apollo-datasource-0.7.1.tgz",
+      "integrity": "sha512-h++/jQAY7GA+4TBM+7ezvctFmmGNLrAPf51KsagZj+NkT9qvxp585rdsuatynVbSl59toPK2EuVmc6ilmQHf+g==",
+      "requires": {
+        "apollo-server-caching": "^0.5.1",
+        "apollo-server-env": "^2.4.4"
+      }
+    },
+    "apollo-engine-reporting": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/apollo-engine-reporting/-/apollo-engine-reporting-2.1.0.tgz",
+      "integrity": "sha512-D6T126ye190s+p/2aUPdFDeHTGg/zt2rHtH/nKLJEaMPsI2oBY71b+nq44umG7cjIbZAtTWZLFOewZkJTu3qAA==",
+      "requires": {
+        "apollo-engine-reporting-protobuf": "^0.5.1",
+        "apollo-graphql": "^0.4.0",
+        "apollo-server-caching": "^0.5.1",
+        "apollo-server-env": "^2.4.4",
+        "apollo-server-errors": "^2.4.1",
+        "apollo-server-plugin-base": "^0.9.0",
+        "apollo-server-types": "^0.5.0",
+        "async-retry": "^1.2.1",
+        "uuid": "^8.0.0"
+      },
+      "dependencies": {
+        "apollo-server-types": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/apollo-server-types/-/apollo-server-types-0.5.0.tgz",
+          "integrity": "sha512-zhtsqqqfdeoJQAfc41Sy6WnnBVxKNgZ34BKXf/Q+kXmw7rbZ/B5SG3SJMvj1iFsbzZxILmWdUsE9aD20lEr0bg==",
+          "requires": {
+            "apollo-engine-reporting-protobuf": "^0.5.1",
+            "apollo-server-caching": "^0.5.1",
+            "apollo-server-env": "^2.4.4"
+          }
+        },
+        "uuid": {
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.1.0.tgz",
+          "integrity": "sha512-CI18flHDznR0lq54xBycOVmphdCYnQLKn8abKn7PXUiKUGdEd+/l9LWNJmugXel4hXq7S+RMNl34ecyC9TntWg=="
+        }
+      }
+    },
+    "apollo-engine-reporting-protobuf": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/apollo-engine-reporting-protobuf/-/apollo-engine-reporting-protobuf-0.5.1.tgz",
+      "integrity": "sha512-TSfr9iAaInV8dhXkesdcmqsthRkVcJkzznmiM+1Ob/GScK7r6hBYCjVDt2613EHAg9SUzTOltIKlGD+N+GJRUw==",
+      "requires": {
+        "@apollo/protobufjs": "^1.0.3"
+      }
+    },
+    "apollo-env": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/apollo-env/-/apollo-env-0.6.5.tgz",
+      "integrity": "sha512-jeBUVsGymeTHYWp3me0R2CZRZrFeuSZeICZHCeRflHTfnQtlmbSXdy5E0pOyRM9CU4JfQkKDC98S1YglQj7Bzg==",
+      "requires": {
+        "@types/node-fetch": "2.5.7",
+        "core-js": "^3.0.1",
+        "node-fetch": "^2.2.0",
+        "sha.js": "^2.4.11"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "3.6.5",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz",
+          "integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA=="
+        }
+      }
+    },
+    "apollo-graphql": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/apollo-graphql/-/apollo-graphql-0.4.5.tgz",
+      "integrity": "sha512-0qa7UOoq7E71kBYE7idi6mNQhHLVdMEDInWk6TNw3KsSWZE2/I68gARP84Mj+paFTO5NYuw1Dht66PVX76Cc2w==",
+      "requires": {
+        "apollo-env": "^0.6.5",
+        "lodash.sortby": "^4.7.0"
+      }
+    },
+    "apollo-link": {
+      "version": "1.2.14",
+      "resolved": "https://registry.npmjs.org/apollo-link/-/apollo-link-1.2.14.tgz",
+      "integrity": "sha512-p67CMEFP7kOG1JZ0ZkYZwRDa369w5PIjtMjvrQd/HnIV8FRsHRqLqK+oAZQnFa1DDdZtOtHTi+aMIW6EatC2jg==",
+      "requires": {
+        "apollo-utilities": "^1.3.0",
+        "ts-invariant": "^0.4.0",
+        "tslib": "^1.9.3",
+        "zen-observable-ts": "^0.8.21"
+      }
+    },
+    "apollo-server-caching": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/apollo-server-caching/-/apollo-server-caching-0.5.1.tgz",
+      "integrity": "sha512-L7LHZ3k9Ao5OSf2WStvQhxdsNVplRQi7kCAPfqf9Z3GBEnQ2uaL0EgO0hSmtVHfXTbk5CTRziMT1Pe87bXrFIw==",
+      "requires": {
+        "lru-cache": "^5.0.0"
+      }
+    },
+    "apollo-server-core": {
+      "version": "2.14.5",
+      "resolved": "https://registry.npmjs.org/apollo-server-core/-/apollo-server-core-2.14.5.tgz",
+      "integrity": "sha512-7zlZvVM2yIThBJBcPmiBwhxJ5vK65duUui4fcneh/A0ubOZUNgpTVbqK8dhSMUNhR6NvYIpzHFJDt1Kb5MuDdw==",
+      "requires": {
+        "@apollographql/apollo-tools": "^0.4.3",
+        "@apollographql/graphql-playground-html": "1.6.26",
+        "@types/graphql-upload": "^8.0.0",
+        "@types/ws": "^7.0.0",
+        "apollo-cache-control": "^0.11.0",
+        "apollo-datasource": "^0.7.1",
+        "apollo-engine-reporting": "^2.1.0",
+        "apollo-server-caching": "^0.5.1",
+        "apollo-server-env": "^2.4.4",
+        "apollo-server-errors": "^2.4.1",
+        "apollo-server-plugin-base": "^0.9.0",
+        "apollo-server-types": "^0.5.0",
+        "apollo-tracing": "^0.11.0",
+        "fast-json-stable-stringify": "^2.0.0",
+        "graphql-extensions": "^0.12.3",
+        "graphql-tag": "^2.9.2",
+        "graphql-tools": "^4.0.0",
+        "graphql-upload": "^8.0.2",
+        "loglevel": "^1.6.7",
+        "sha.js": "^2.4.11",
+        "subscriptions-transport-ws": "^0.9.11",
+        "ws": "^6.0.0"
+      },
+      "dependencies": {
+        "@apollographql/graphql-playground-html": {
+          "version": "1.6.26",
+          "resolved": "https://registry.npmjs.org/@apollographql/graphql-playground-html/-/graphql-playground-html-1.6.26.tgz",
+          "integrity": "sha512-XAwXOIab51QyhBxnxySdK3nuMEUohhDsHQ5Rbco/V1vjlP75zZ0ZLHD9dTpXTN8uxKxopb2lUvJTq+M4g2Q0HQ==",
+          "requires": {
+            "xss": "^1.0.6"
+          }
+        },
+        "apollo-server-types": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/apollo-server-types/-/apollo-server-types-0.5.0.tgz",
+          "integrity": "sha512-zhtsqqqfdeoJQAfc41Sy6WnnBVxKNgZ34BKXf/Q+kXmw7rbZ/B5SG3SJMvj1iFsbzZxILmWdUsE9aD20lEr0bg==",
+          "requires": {
+            "apollo-engine-reporting-protobuf": "^0.5.1",
+            "apollo-server-caching": "^0.5.1",
+            "apollo-server-env": "^2.4.4"
+          }
+        }
+      }
+    },
+    "apollo-server-env": {
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/apollo-server-env/-/apollo-server-env-2.4.4.tgz",
+      "integrity": "sha512-c2oddDS3lwAl6QNCIKCLEzt/dF9M3/tjjYRVdxOVN20TidybI7rAbnT4QOzf4tORnGXtiznEAvr/Kc9ahhKADg==",
+      "requires": {
+        "node-fetch": "^2.1.2",
+        "util.promisify": "^1.0.0"
+      }
+    },
+    "apollo-server-errors": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/apollo-server-errors/-/apollo-server-errors-2.4.1.tgz",
+      "integrity": "sha512-7oEd6pUxqyWYUbQ9TA8tM0NU/3aGtXSEibo6+txUkuHe7QaxfZ2wHRp+pfT1LC1K3RXYjKj61/C2xEO19s3Kdg=="
+    },
+    "apollo-server-koa": {
+      "version": "2.9.12",
+      "resolved": "https://registry.npmjs.org/apollo-server-koa/-/apollo-server-koa-2.9.12.tgz",
+      "integrity": "sha512-LPICtgDhiJPJkxWcaVE1ReAGM1ajKlU1EZru7oIUjrO8S/helkvdUKTDy6Bu+GSYP6PwiHo68mI2kChecPZJkg==",
+      "requires": {
+        "@apollographql/graphql-playground-html": "1.6.24",
+        "@koa/cors": "^2.2.1",
+        "@types/accepts": "^1.3.5",
+        "@types/cors": "^2.8.4",
+        "@types/koa": "^2.0.46",
+        "@types/koa-bodyparser": "^4.2.1",
+        "@types/koa-compose": "^3.2.2",
+        "@types/koa__cors": "^2.2.1",
+        "accepts": "^1.3.5",
+        "apollo-server-core": "^2.9.12",
+        "apollo-server-types": "^0.2.8",
+        "graphql-subscriptions": "^1.0.0",
+        "graphql-tools": "^4.0.0",
+        "koa": "2.11.0",
+        "koa-bodyparser": "^4.2.1",
+        "koa-compose": "^4.1.0",
+        "koa-router": "^7.4.0",
+        "type-is": "^1.6.16"
+      },
+      "dependencies": {
+        "@koa/cors": {
+          "version": "2.2.3",
+          "resolved": "https://registry.npmjs.org/@koa/cors/-/cors-2.2.3.tgz",
+          "integrity": "sha512-tCVVXa39ETsit5kGBtEWWimjLn1sDaeu8+0phgb8kT3GmBDZOykkI3ZO8nMjV2p3MGkJI4K5P+bxR8Ztq0bwsA==",
+          "requires": {
+            "vary": "^1.1.2"
+          }
+        },
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "koa": {
+          "version": "2.11.0",
+          "resolved": "https://registry.npmjs.org/koa/-/koa-2.11.0.tgz",
+          "integrity": "sha512-EpR9dElBTDlaDgyhDMiLkXrPwp6ZqgAIBvhhmxQ9XN4TFgW+gEz6tkcsNI6BnUbUftrKDjVFj4lW2/J2aNBMMA==",
+          "requires": {
+            "accepts": "^1.3.5",
+            "cache-content-type": "^1.0.0",
+            "content-disposition": "~0.5.2",
+            "content-type": "^1.0.4",
+            "cookies": "~0.8.0",
+            "debug": "~3.1.0",
+            "delegates": "^1.0.0",
+            "depd": "^1.1.2",
+            "destroy": "^1.0.4",
+            "encodeurl": "^1.0.2",
+            "error-inject": "^1.0.0",
+            "escape-html": "^1.0.3",
+            "fresh": "~0.5.2",
+            "http-assert": "^1.3.0",
+            "http-errors": "^1.6.3",
+            "is-generator-function": "^1.0.7",
+            "koa-compose": "^4.1.0",
+            "koa-convert": "^1.2.0",
+            "on-finished": "^2.3.0",
+            "only": "~0.0.2",
+            "parseurl": "^1.3.2",
+            "statuses": "^1.5.0",
+            "type-is": "^1.6.16",
+            "vary": "^1.1.2"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
+      }
+    },
+    "apollo-server-plugin-base": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/apollo-server-plugin-base/-/apollo-server-plugin-base-0.9.0.tgz",
+      "integrity": "sha512-LWcPrsy2+xqwlNseh/QaGa/MPNopS8c4qGgh0g0cAn0lZBRrJ9Yab7dq+iQ6vdUBwIhUWYN6s9dwUWCZw2SL8g==",
+      "requires": {
+        "apollo-server-types": "^0.5.0"
+      },
+      "dependencies": {
+        "apollo-server-types": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/apollo-server-types/-/apollo-server-types-0.5.0.tgz",
+          "integrity": "sha512-zhtsqqqfdeoJQAfc41Sy6WnnBVxKNgZ34BKXf/Q+kXmw7rbZ/B5SG3SJMvj1iFsbzZxILmWdUsE9aD20lEr0bg==",
+          "requires": {
+            "apollo-engine-reporting-protobuf": "^0.5.1",
+            "apollo-server-caching": "^0.5.1",
+            "apollo-server-env": "^2.4.4"
+          }
+        }
+      }
+    },
+    "apollo-server-types": {
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/apollo-server-types/-/apollo-server-types-0.2.10.tgz",
+      "integrity": "sha512-ke9ViPEWfW+2XLe66CaKGVZdS7duSLbamSKSprmmeMBd8s6tmjf0FumUVxV7X4quxPZi0OPo8x0LoLU7GWsmaA==",
+      "requires": {
+        "apollo-engine-reporting-protobuf": "^0.4.4",
+        "apollo-server-caching": "^0.5.1",
+        "apollo-server-env": "^2.4.3"
+      },
+      "dependencies": {
+        "apollo-engine-reporting-protobuf": {
+          "version": "0.4.4",
+          "resolved": "https://registry.npmjs.org/apollo-engine-reporting-protobuf/-/apollo-engine-reporting-protobuf-0.4.4.tgz",
+          "integrity": "sha512-SGrIkUR7Q/VjU8YG98xcvo340C4DaNUhg/TXOtGsMlfiJDzHwVau/Bv6zifAzBafp2lj0XND6Daj5kyT/eSI/w==",
+          "requires": {
+            "@apollo/protobufjs": "^1.0.3"
+          }
+        }
+      }
+    },
+    "apollo-tracing": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/apollo-tracing/-/apollo-tracing-0.11.0.tgz",
+      "integrity": "sha512-I9IFb/8lkBW8ZwOAi4LEojfT7dMfUSkpnV8LHQI8Rcj0HtzL9HObQ3woBmzyGHdGHLFuD/6/VHyFD67SesSrJg==",
+      "requires": {
+        "apollo-server-env": "^2.4.4",
+        "apollo-server-plugin-base": "^0.9.0"
+      }
+    },
+    "apollo-utilities": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/apollo-utilities/-/apollo-utilities-1.3.4.tgz",
+      "integrity": "sha512-pk2hiWrCXMAy2fRPwEyhvka+mqwzeP60Jr1tRYi5xru+3ko94HI9o6lK0CT33/w4RDlxWchmdhDCrvdr+pHCig==",
+      "requires": {
+        "@wry/equality": "^0.1.2",
+        "fast-json-stable-stringify": "^2.0.0",
+        "ts-invariant": "^0.4.0",
+        "tslib": "^1.10.0"
+      }
+    },
     "aproba": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
@@ -1865,6 +2469,11 @@
         "define-properties": "^1.1.3",
         "es-abstract": "^1.17.0-next.1"
       }
+    },
+    "arrify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
     },
     "asap": {
       "version": "2.0.6",
@@ -1952,6 +2561,14 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
       "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ=="
+    },
+    "async-retry": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.1.tgz",
+      "integrity": "sha512-aiieFW/7h3hY0Bq5d+ktDBejxuwR78vRu9hDUdR8rNhSaQ29VzPL4AoIRG7D/c7tdenwOcKvgPM6tIxB3cB6HA==",
+      "requires": {
+        "retry": "0.12.0"
+      }
     },
     "asynckit": {
       "version": "0.4.0",
@@ -2074,6 +2691,11 @@
         }
       }
     },
+    "backo2": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz",
+      "integrity": "sha1-MasayLEpNjRj41s+u2n038+6eUc="
+    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -2161,6 +2783,15 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.0.0.tgz",
       "integrity": "sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow=="
+    },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
     },
     "bl": {
       "version": "4.0.2",
@@ -2487,6 +3118,14 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
       "integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug="
+    },
+    "busboy": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-0.3.1.tgz",
+      "integrity": "sha512-y7tTxhGKXcyBxRKAni+awqx8uqaJKrSFSNFSeRG5CsWNdmy2BIK+6VGWEW7TZnIO/533mtMEA4rOevQV815YJw==",
+      "requires": {
+        "dicer": "0.3.0"
+      }
     },
     "byte-size": {
       "version": "6.2.0",
@@ -3060,6 +3699,11 @@
       "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
     },
+    "copy-to": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/copy-to/-/copy-to-2.0.1.tgz",
+      "integrity": "sha1-JoD7uAaKSNCGVrYJgJK9r8kG9KU="
+    },
     "copy-to-clipboard": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/copy-to-clipboard/-/copy-to-clipboard-3.3.1.tgz",
@@ -3287,6 +3931,11 @@
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
       "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg=="
     },
+    "cssfilter": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/cssfilter/-/cssfilter-0.0.10.tgz",
+      "integrity": "sha1-xtJnJjKi5cg+AT5oZKQs6N79IK4="
+    },
     "csstype": {
       "version": "2.6.10",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.10.tgz",
@@ -3304,6 +3953,11 @@
       "requires": {
         "assert-plus": "^1.0.0"
       }
+    },
+    "dataloader": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/dataloader/-/dataloader-1.4.0.tgz",
+      "integrity": "sha512-68s5jYdlvasItOJnCuI2Q9s4q98g0pCyL3HrcKJu8KNugUl8ahgmZYg38ysLTgQjjXX3H8CJLkAvWrclWfcalw=="
     },
     "date-fns": {
       "version": "2.14.0",
@@ -3452,6 +4106,11 @@
       "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
       "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
     },
+    "deprecated-decorator": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/deprecated-decorator/-/deprecated-decorator-0.1.6.tgz",
+      "integrity": "sha1-AJZjF7ehL+kvPMgx91g68ym4bDc="
+    },
     "des.js": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.1.tgz",
@@ -3480,6 +4139,14 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.0.4.tgz",
       "integrity": "sha512-ZIzRpLJrOj7jjP2miAtgqIfmzbxa4ZOr5jJc601zklsfEx9oTzmmj2nVpIPRpNlRTIh8lc1kyViIY7BWSGNmKw=="
+    },
+    "dicer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/dicer/-/dicer-0.3.0.tgz",
+      "integrity": "sha512-MdceRRWqltEG2dZqO769g27N/3PXfcKl04VhYnBlo2YhH7zPi88VebsjTKclaOyiuMaGU72hTfw3VkUitGcVCA==",
+      "requires": {
+        "streamsearch": "0.1.2"
+      }
     },
     "diffie-hellman": {
       "version": "5.0.3",
@@ -3784,6 +4451,11 @@
       "requires": {
         "is-arrayish": "^0.2.1"
       }
+    },
+    "error-inject": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/error-inject/-/error-inject-1.0.0.tgz",
+      "integrity": "sha1-4rPZG1Su1nLzCdlQ0VSFD6EdTzc="
     },
     "error-stack-parser": {
       "version": "2.0.6",
@@ -4233,6 +4905,12 @@
         }
       }
     },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "optional": true
+    },
     "filename-reserved-regex": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-2.0.0.tgz",
@@ -4464,6 +5142,11 @@
         "inherits": "^2.0.1",
         "readable-stream": "^2.0.0"
       }
+    },
+    "fs-capacitor": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/fs-capacitor/-/fs-capacitor-2.0.4.tgz",
+      "integrity": "sha512-8S4f4WsCryNw2mJJchi46YgB6CR5Ze+4L1h8ewl9tEpL4SJ3ZO+c/bS4BWhB8bK+O3TMqhuZarTitd0S0eh2pA=="
     },
     "fs-constants": {
       "version": "1.0.0",
@@ -4721,6 +5404,111 @@
       "integrity": "sha512-dvu6FgtFOXncHM3faiJKehMN+4cRajb68E0FtmT5uMUUHZ4LZifv6ihANH9l0pvl0t+7UjEIosMrhnE73bhjpQ==",
       "requires": {
         "grant": "4.7.0"
+      }
+    },
+    "graphql": {
+      "version": "14.6.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-14.6.0.tgz",
+      "integrity": "sha512-VKzfvHEKybTKjQVpTFrA5yUq2S9ihcZvfJAtsDBBCuV6wauPu1xl/f9ehgVf0FcEJJs4vz6ysb/ZMkGigQZseg==",
+      "requires": {
+        "iterall": "^1.2.2"
+      }
+    },
+    "graphql-depth-limit": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/graphql-depth-limit/-/graphql-depth-limit-1.1.0.tgz",
+      "integrity": "sha512-+3B2BaG8qQ8E18kzk9yiSdAa75i/hnnOwgSeAxVJctGQPvmeiLtqKOYF6HETCyRjiF7Xfsyal0HbLlxCQkgkrw==",
+      "requires": {
+        "arrify": "^1.0.1"
+      }
+    },
+    "graphql-extensions": {
+      "version": "0.12.3",
+      "resolved": "https://registry.npmjs.org/graphql-extensions/-/graphql-extensions-0.12.3.tgz",
+      "integrity": "sha512-W7iT0kzlwTiZU7fXfw9IgWnsqVj7EFLd0/wVcZZRAbR8L3f4+YsGls0oxKdsrvYBnbG347BXKQmIyo6GTEk4XA==",
+      "requires": {
+        "@apollographql/apollo-tools": "^0.4.3",
+        "apollo-server-env": "^2.4.4",
+        "apollo-server-types": "^0.5.0"
+      },
+      "dependencies": {
+        "apollo-server-types": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/apollo-server-types/-/apollo-server-types-0.5.0.tgz",
+          "integrity": "sha512-zhtsqqqfdeoJQAfc41Sy6WnnBVxKNgZ34BKXf/Q+kXmw7rbZ/B5SG3SJMvj1iFsbzZxILmWdUsE9aD20lEr0bg==",
+          "requires": {
+            "apollo-engine-reporting-protobuf": "^0.5.1",
+            "apollo-server-caching": "^0.5.1",
+            "apollo-server-env": "^2.4.4"
+          }
+        }
+      }
+    },
+    "graphql-iso-date": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/graphql-iso-date/-/graphql-iso-date-3.6.1.tgz",
+      "integrity": "sha512-AwFGIuYMJQXOEAgRlJlFL4H1ncFM8n8XmoVDTNypNOZyQ8LFDG2ppMFlsS862BSTCDcSUfHp8PD3/uJhv7t59Q=="
+    },
+    "graphql-playground-html": {
+      "version": "1.6.25",
+      "resolved": "https://registry.npmjs.org/graphql-playground-html/-/graphql-playground-html-1.6.25.tgz",
+      "integrity": "sha512-wMNvGsQ0OwBVhn72VVi7OdpI85IxiIZT43glRx7gQIwQ6NvhFnzMYBIVmcJAJ4UlXRYiWtrQhuOItDXObiR3kg==",
+      "requires": {
+        "xss": "^1.0.6"
+      }
+    },
+    "graphql-playground-middleware-koa": {
+      "version": "1.6.17",
+      "resolved": "https://registry.npmjs.org/graphql-playground-middleware-koa/-/graphql-playground-middleware-koa-1.6.17.tgz",
+      "integrity": "sha512-PbXUn8ZFbXnrhCIYHDFK6optnQb2r0mtKY4lE4WX7voXyogqkXx4+phQAXXtLrA2iypPhY/wZgoY4nLHdL4tyg==",
+      "requires": {
+        "graphql-playground-html": "1.6.25"
+      }
+    },
+    "graphql-subscriptions": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/graphql-subscriptions/-/graphql-subscriptions-1.1.0.tgz",
+      "integrity": "sha512-6WzlBFC0lWmXJbIVE8OgFgXIP4RJi3OQgTPa0DVMsDXdpRDjTsM1K9wfl5HSYX7R87QAGlvcv2Y4BIZa/ItonA==",
+      "requires": {
+        "iterall": "^1.2.1"
+      }
+    },
+    "graphql-tag": {
+      "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.10.3.tgz",
+      "integrity": "sha512-4FOv3ZKfA4WdOKJeHdz6B3F/vxBLSgmBcGeAFPf4n1F64ltJUvOOerNj0rsJxONQGdhUMynQIvd6LzB+1J5oKA=="
+    },
+    "graphql-tools": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/graphql-tools/-/graphql-tools-4.0.6.tgz",
+      "integrity": "sha512-jHLQw8x3xmSNRBCsaZqelXXsFfUSUSktSCUP8KYHiX1Z9qEuwcMpAf+FkdBzk8aTAFqOlPdNZ3OI4DKKqGKUqg==",
+      "requires": {
+        "apollo-link": "^1.2.3",
+        "apollo-utilities": "^1.0.1",
+        "deprecated-decorator": "^0.1.6",
+        "iterall": "^1.1.3",
+        "uuid": "^3.1.0"
+      }
+    },
+    "graphql-type-json": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/graphql-type-json/-/graphql-type-json-0.3.1.tgz",
+      "integrity": "sha512-1lPkUXQ2L8o+ERLzVAuc3rzc/E6pGF+6HnjihCVTK0VzR0jCuUd92FqNxoHdfILXqOn2L6b4y47TBxiPyieUVA=="
+    },
+    "graphql-type-long": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/graphql-type-long/-/graphql-type-long-0.1.1.tgz",
+      "integrity": "sha512-pIp/F3LR0qqfbF4TX3CwBwPskA7850KG6/DnzaYJtdgxxzw20dcKfutLbyk8okBGg8iHbFoXgnZWHgfwNmxSZw=="
+    },
+    "graphql-upload": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/graphql-upload/-/graphql-upload-8.1.0.tgz",
+      "integrity": "sha512-U2OiDI5VxYmzRKw0Z2dmfk0zkqMRaecH9Smh1U277gVgVe9Qn+18xqf4skwr4YJszGIh7iQDZ57+5ygOK9sM/Q==",
+      "requires": {
+        "busboy": "^0.3.1",
+        "fs-capacitor": "^2.0.4",
+        "http-errors": "^1.7.3",
+        "object-path": "^0.11.4"
       }
     },
     "gud": {
@@ -5634,6 +6422,11 @@
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
     },
+    "iterall": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/iterall/-/iterall-1.3.0.tgz",
+      "integrity": "sha512-QZ9qOMdF+QLHxy1QIpUHUU1D5pS2CG2P69LF6L6CPjPYA/XMOmKV3PZpawHoAjHNyB0swdVTRxdYT4tbBbxqwg=="
+    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -5820,6 +6613,28 @@
         "@types/formidable": "^1.0.31",
         "co-body": "^5.1.1",
         "formidable": "^1.1.1"
+      }
+    },
+    "koa-bodyparser": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/koa-bodyparser/-/koa-bodyparser-4.3.0.tgz",
+      "integrity": "sha512-uyV8G29KAGwZc4q/0WUAjH+Tsmuv9ImfBUF2oZVyZtaeo0husInagyn/JH85xMSxM0hEk/mbCII5ubLDuqW/Rw==",
+      "requires": {
+        "co-body": "^6.0.0",
+        "copy-to": "^2.0.1"
+      },
+      "dependencies": {
+        "co-body": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/co-body/-/co-body-6.0.0.tgz",
+          "integrity": "sha512-9ZIcixguuuKIptnY8yemEOuhb71L/lLf+Rl5JfJEUiDNJk0e02MBt7BPxR2GEh5mw8dPthQYR4jPI/BnS1MQgw==",
+          "requires": {
+            "inflation": "^2.0.0",
+            "qs": "^6.5.2",
+            "raw-body": "^2.3.3",
+            "type-is": "^1.6.16"
+          }
+        }
       }
     },
     "koa-compose": {
@@ -6168,6 +6983,11 @@
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
       "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
     },
+    "lodash.sortby": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+      "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg="
+    },
     "lodash.throttle": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
@@ -6185,6 +7005,11 @@
       "version": "1.6.8",
       "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.6.8.tgz",
       "integrity": "sha512-bsU7+gc9AJ2SqpzxwU3+1fedl8zAntbtC5XYlt3s2j1hJcn2PsXSmgN8TaLG/J1/2mod4+cE/3vNL70/c1RNCA=="
+    },
+    "long": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
+      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
     },
     "long-timeout": {
       "version": "0.1.1",
@@ -7033,6 +7858,11 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
       "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
+    },
+    "object-path": {
+      "version": "0.11.4",
+      "resolved": "https://registry.npmjs.org/object-path/-/object-path-0.11.4.tgz",
+      "integrity": "sha1-NwrnUvvzfePqcKhhwju6iRVpGUk="
     },
     "object-visit": {
       "version": "1.0.1",
@@ -10020,6 +10850,34 @@
         "strapi-utils": "3.0.0-beta.20.3"
       }
     },
+    "strapi-plugin-graphql": {
+      "version": "3.0.0-beta.20.3",
+      "resolved": "https://registry.npmjs.org/strapi-plugin-graphql/-/strapi-plugin-graphql-3.0.0-beta.20.3.tgz",
+      "integrity": "sha512-sv60vLb7+j5vhUdH9D5wM+YdjWFD5GbPy5hp5Vtn+QHLNnBwRemY66YcsSbN89IOi+3l7hN0RfgpqiELTZiRYg==",
+      "requires": {
+        "apollo-server-koa": "2.9.12",
+        "dataloader": "^1.4.0",
+        "glob": "^7.1.4",
+        "graphql": "^14.3.0",
+        "graphql-depth-limit": "^1.1.0",
+        "graphql-iso-date": "^3.6.1",
+        "graphql-playground-middleware-koa": "^1.6.0",
+        "graphql-tools": "4.0.6",
+        "graphql-type-json": "0.3.1",
+        "graphql-type-long": "^0.1.1",
+        "koa-compose": "^4.1.0",
+        "lodash": "4.17.11",
+        "pluralize": "^7.0.0",
+        "strapi-utils": "3.0.0-beta.20.3"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+        }
+      }
+    },
     "strapi-plugin-upload": {
       "version": "3.0.0-beta.20.3",
       "resolved": "https://registry.npmjs.org/strapi-plugin-upload/-/strapi-plugin-upload-3.0.0-beta.20.3.tgz",
@@ -10177,6 +11035,11 @@
         "any-promise": "^1.1.0"
       }
     },
+    "streamsearch": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-0.1.2.tgz",
+      "integrity": "sha1-gIudDlb8Jz2Am6VzOOkpkZoanxo="
+    },
     "strict-uri-encode": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
@@ -10299,6 +11162,33 @@
         "hoist-non-react-statics": "^3.0.0",
         "shallowequal": "^1.1.0",
         "supports-color": "^5.5.0"
+      }
+    },
+    "subscriptions-transport-ws": {
+      "version": "0.9.16",
+      "resolved": "https://registry.npmjs.org/subscriptions-transport-ws/-/subscriptions-transport-ws-0.9.16.tgz",
+      "integrity": "sha512-pQdoU7nC+EpStXnCfh/+ho0zE0Z+ma+i7xvj7bkXKb1dvYHSZxgRPaU6spRP+Bjzow67c/rRDoix5RT0uU9omw==",
+      "requires": {
+        "backo2": "^1.0.2",
+        "eventemitter3": "^3.1.0",
+        "iterall": "^1.2.1",
+        "symbol-observable": "^1.0.4",
+        "ws": "^5.2.0"
+      },
+      "dependencies": {
+        "eventemitter3": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
+          "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q=="
+        },
+        "ws": {
+          "version": "5.2.2",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.2.tgz",
+          "integrity": "sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==",
+          "requires": {
+            "async-limiter": "~1.0.0"
+          }
+        }
       }
     },
     "supports-color": {
@@ -10595,6 +11485,14 @@
       "integrity": "sha1-42RqLqTokTEr9+rObPsFOAvAHCE=",
       "requires": {
         "escape-string-regexp": "^1.0.2"
+      }
+    },
+    "ts-invariant": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.4.4.tgz",
+      "integrity": "sha512-uEtWkFM/sdZvRNNDL3Ehu4WVpwaulhwQszV8mrtcdeE8nN00BV9mAmQ88RkrBhFgl9gMgvjJLAQcZbnPXI9mlA==",
+      "requires": {
+        "tslib": "^1.9.3"
       }
     },
     "tslib": {
@@ -11100,6 +11998,7 @@
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
           "optional": true,
           "requires": {
+            "bindings": "^1.5.0",
             "nan": "^2.12.1"
           }
         },
@@ -11443,6 +12342,7 @@
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
           "optional": true,
           "requires": {
+            "bindings": "^1.5.0",
             "nan": "^2.12.1"
           }
         },
@@ -11779,6 +12679,15 @@
         "async-limiter": "~1.0.0"
       }
     },
+    "xss": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/xss/-/xss-1.0.7.tgz",
+      "integrity": "sha512-A9v7tblGvxu8TWXQC9rlpW96a+LN1lyw6wyhpTmmGW+FwRMactchBR3ROKSi33UPCUcUHSu8s9YP6F+K3Mw//w==",
+      "requires": {
+        "commander": "^2.20.3",
+        "cssfilter": "0.0.10"
+      }
+    },
     "xtend": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
@@ -11906,6 +12815,20 @@
         "property-expr": "^1.5.0",
         "synchronous-promise": "^2.0.6",
         "toposort": "^2.0.2"
+      }
+    },
+    "zen-observable": {
+      "version": "0.8.15",
+      "resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.8.15.tgz",
+      "integrity": "sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ=="
+    },
+    "zen-observable-ts": {
+      "version": "0.8.21",
+      "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-0.8.21.tgz",
+      "integrity": "sha512-Yj3yXweRc8LdRMrCC8nIc4kkjWecPAUVh0TI0OUrWXx6aX790vLcDlWca6I4vsyCGH3LpWxq0dJRcMOFoVqmeg==",
+      "requires": {
+        "tslib": "^1.9.3",
+        "zen-observable": "^0.8.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -13,13 +13,14 @@
   "dependencies": {
     "strapi": "3.0.0-beta.20.3",
     "strapi-admin": "3.0.0-beta.20.3",
-    "strapi-utils": "3.0.0-beta.20.3",
-    "strapi-plugin-content-type-builder": "3.0.0-beta.20.3",
+    "strapi-connector-mongoose": "3.0.0-beta.20.3",
     "strapi-plugin-content-manager": "3.0.0-beta.20.3",
-    "strapi-plugin-users-permissions": "3.0.0-beta.20.3",
+    "strapi-plugin-content-type-builder": "3.0.0-beta.20.3",
     "strapi-plugin-email": "3.0.0-beta.20.3",
+    "strapi-plugin-graphql": "^3.0.0-beta.20.3",
     "strapi-plugin-upload": "3.0.0-beta.20.3",
-    "strapi-connector-mongoose": "3.0.0-beta.20.3"
+    "strapi-plugin-users-permissions": "3.0.0-beta.20.3",
+    "strapi-utils": "3.0.0-beta.20.3"
   },
   "author": {
     "name": "A Strapi developer"


### PR DESCRIPTION
This is added so that PWA could run apollo GraphQL at runtime. This will lead to the ability to deprecate gatsby-source-strapi and only run the queries at runtime. As a result the Client PWA will not need to be rebuilt with every change to server side data 💯  🥇 